### PR TITLE
fix: update docs Github repo

### DIFF
--- a/erpnext_documentation/www/docs/index.html
+++ b/erpnext_documentation/www/docs/index.html
@@ -63,7 +63,7 @@
 				blogs.<br><br>
 
 				You're encouraged to help improve the quality of this documentation, by
-				sending a pull request on the <a href="https://github.com/frappe/erpnext_com">GitHub Repository</a>.
+				sending a pull request on the <a href="https://github.com/frappe/erpnext_documentation">GitHub Repository</a>.
 				If you would like to have a discussion regarding the documentation,
 				you can do so <a href="https://discuss.erpnext.com">at the forum</a>.
 			</p>


### PR DESCRIPTION
Repo is still directed towards https://github.com/frappe/erpnext_com