### PR TITLE
docs: Fix translation page

### DIFF
--- a/erpnext_documentation/www/docs/user/manual/en/translations.md
+++ b/erpnext_documentation/www/docs/user/manual/en/translations.md
@@ -1,4 +1,4 @@
-<!-- base_template: frappe_io/www/frappe/frappe_base.html --><!-- add-breadcrumbs -->
+<!-- add-breadcrumbs -->
 # Translations
 
 **ERPNext is available in more than 80 languages most of which has been contributed by ERPNext community.**


### PR DESCRIPTION
Remove `<!-- base_template: frappe_io/www/frappe/frappe_base.html -->`

To avoid 
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/jinja.py", line 77, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
jinja2.exceptions.TemplateNotFound: frappe_io/www/frappe/frappe_base.html

```