### PR TITLE
fix: assessment plan image correction

### DIFF
--- a/erpnext_documentation/www/docs/user/manual/en/education/assessment_plan.md
+++ b/erpnext_documentation/www/docs/user/manual/en/education/assessment_plan.md
@@ -47,7 +47,7 @@ Apart from the mandatory fields, you may also add the following details to the a
 1. **Examiner**: Add the name of the Examining Instructor for this assessment.
 1. **Supervisor**: Add the name of the Supervising Instructor for this assessment.
 
-![Assessment Plan](/docs/assets/img/education/education-assessment-plan-2)
+![Assessment Plan](/docs/assets/img/education/education-assessment-plan-2.png)
 
 ### 3.2. Evaluate
 


### PR DESCRIPTION
**Issue:**

1. In Assessment Plan documentation section 3.1 the image used to not appear because of missing .png.

![Screenshot 2020-11-19 at 5 08 48 PM](https://user-images.githubusercontent.com/31363128/99661587-115b9480-2a8a-11eb-8356-2d556b30f5f3.png)

**Fix:**

1. Added .png after image in section 3.1

![Screenshot 2020-11-19 at 5 09 02 PM](https://user-images.githubusercontent.com/31363128/99661630-233d3780-2a8a-11eb-8da4-5ca5b698f3b2.png)
