### PR TITLE
fix: buying settings

### DIFF
--- a/erpnext_documentation/www/docs/user/manual/en/buying/buying-settings.md
+++ b/erpnext_documentation/www/docs/user/manual/en/buying/buying-settings.md
@@ -41,7 +41,7 @@ This configuration can be overridden for a particular supplier by enabling the "
 
 If this option is configured "Yes", ERPNext will prevent you from creating a Purchase Invoice without creating a Purchase Receipt first. In case the Item being transacted is a service, it'll not require a receipt, you can directly create an Invoice.
 
-This configuration can be overridden for a particular supplier by enabling the "Allow Purchase Invoice Creation Without Purchase Receipt" checkbox in supplier master
+This configuration can be overridden for a particular supplier by enabling the "Allow Purchase Invoice Creation Without Purchase Receipt" checkbox in the supplier master
 
 <img alt="Purchase Receipt Required" class="screenshot" src="{{docs_base_url}}/assets/img/buying/pr-required.png">
 

--- a/erpnext_documentation/www/docs/user/manual/en/buying/buying-settings.md
+++ b/erpnext_documentation/www/docs/user/manual/en/buying/buying-settings.md
@@ -41,7 +41,7 @@ This configuration can be overridden for a particular supplier by enabling the "
 
 If this option is configured "Yes", ERPNext will prevent you from creating a Purchase Invoice without creating a Purchase Receipt first. In case the Item being transacted is a service, it'll not require a receipt, you can directly create an Invoice.
 
-This configuration can be overridden for a particular supplier by enabling the "Allow Purchase Receipt Creation Without Purchase Receipt" checkbox in supplier master
+This configuration can be overridden for a particular supplier by enabling the "Allow Purchase Invoice Creation Without Purchase Receipt" checkbox in supplier master
 
 <img alt="Purchase Receipt Required" class="screenshot" src="{{docs_base_url}}/assets/img/buying/pr-required.png">
 


### PR DESCRIPTION
In Buying setting document there is was an incorrect sentence.

**Allow Purchase Receipt Creation Without Purchase Receipt** should be **Allow Purchase Invoice Creation Without Purchase Receipt**

