### PR TITLE
docs: replace 'click here's with descriptive links

### DIFF
--- a/erpnext_documentation/www/docs/user/manual/en/CRM/opportunity.md
+++ b/erpnext_documentation/www/docs/user/manual/en/CRM/opportunity.md
@@ -76,7 +76,7 @@ When an opportunity is lost, you can capture the reasons for losing. This will h
 
 When you send the first reply(email) to an Opportunity, it calculates Mins to First Response and is displayed in a field.
 
-A report is generated called 'Minutes to First Response for Opportunity'. For more details [click here](/docs/user/manual/en/CRM/crm_reports).
+A report is generated called 'Minutes to First Response for Opportunity'. Read [CRM Reports](/docs/user/manual/en/CRM/crm_reports) for more details.
 ### 3. Related Topics
 1. [Quotation](/docs/user/manual/en/selling/quotation.html)
 1. [Customer](/docs/user/manual/en/CRM/customer)

--- a/erpnext_documentation/www/docs/user/manual/en/accounts/articles/fiscal-year-error.md
+++ b/erpnext_documentation/www/docs/user/manual/en/accounts/articles/fiscal-year-error.md
@@ -13,7 +13,7 @@ Only User with System Manager's Role Assigned has permission to create new Fisca
 
 `Accounts > Setup > Fiscal Year`
 
-Click [here](/docs/user/manual/en/accounts/fiscal-year) to learn more about Fiscal Year.
+Read [Fiscal Year](/docs/user/manual/en/accounts/fiscal-year) to learn more.
 
 #### Set Fiscal Year as Default
 

--- a/erpnext_documentation/www/docs/user/manual/en/accounts/articles/recurring-orders-and-invoices.md
+++ b/erpnext_documentation/www/docs/user/manual/en/accounts/articles/recurring-orders-and-invoices.md
@@ -26,7 +26,7 @@ Here is a explanation of the fields:
 * **Repeat on Last Day of the Month:** Recurring invoices will be created on the last day of every month.
 * **Notify by Email:** Email Addresses (separated by comma) on which recurring invoice will be emailed when auto-generated.
 
-For more details about Auto Repeat [Click Here](/docs/user/manual/en/automation/auto-repeat)
+Read [Auto Repeat](/docs/user/manual/en/automation/auto-repeat) for more details.
 
 ## 3. Exception Handling
 

--- a/erpnext_documentation/www/docs/user/manual/en/accounts/journal-entry.md
+++ b/erpnext_documentation/www/docs/user/manual/en/accounts/journal-entry.md
@@ -129,7 +129,7 @@ You can do this by selecting a **Print Heading**. To create new Print Headings g
 
 Home > Settings > Printing > Print Heading
 
-Know more [here](/docs/user/manual/en/setting-up/print/print-headings).
+Read [Print Headings](/docs/user/manual/en/setting-up/print/print-headings) to know more.
 
 ### 2.7 More Information
 

--- a/erpnext_documentation/www/docs/user/manual/en/accounts/pricing-rule.md
+++ b/erpnext_documentation/www/docs/user/manual/en/accounts/pricing-rule.md
@@ -118,7 +118,7 @@ You can also set a date interval for when the Pricing Rule will be valid. This i
 
 * **Margin Rate or Amount**: The margin set can be based on Percentage or Amount, eg: 5% margin or $50 fixed margin.
 
-For more details about adding margins [Click Here](/docs/user/manual/en/selling/articles/adding-margin)
+Read [adding margin](/docs/user/manual/en/selling/articles/adding-margin) for more details.
 
 ### 3.6 Price Discount Scheme
 The actual rule to be applied is set in this section.

--- a/erpnext_documentation/www/docs/user/manual/en/accounts/purchase-invoice.md
+++ b/erpnext_documentation/www/docs/user/manual/en/accounts/purchase-invoice.md
@@ -101,9 +101,9 @@ You can set the currency in which the Purchase Invoice order is to be sent. This
 
 ![PI Price List](/docs/assets/img/accounts/pi-price-list.png)
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
-
-To know about managing transactions in multiple currencies, [click here](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency).
+Read about [Price Lists](/docs/user/manual/en/stock/price-lists)
+and [Multi-Currency Transactions](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency)
+to know more.
 
 ### 3.6 Subcontracting or 'Supply Raw Materials'
 
@@ -111,7 +111,7 @@ Setting 'Supply Raw Materials' option is useful for subcontracting where you pro
 
 ### 3.7 Items table
 
-* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+* **scan barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * The Item Code, name, description, Image, and Manufacturer will be fetched from the [Item master](/docs/user/manual/en/stock/item).
 

--- a/erpnext_documentation/www/docs/user/manual/en/accounts/sales-invoice.md
+++ b/erpnext_documentation/www/docs/user/manual/en/accounts/sales-invoice.md
@@ -101,13 +101,13 @@ For India, the following details can be recorded for GST purposes. You can captu
 You can set the currency in which the Sales Invoice order is to be sent. This can be fetched from the Customer master or preceding transactions like Sales Order.
 
 * Wish to select Customer's currency just for the reference of the Customer, whereas accounts posting will be done in the Company's base currency only. Learn more [here](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency).
-* Maintain separate receivable account in the Customer's currency. The Receivable for this invoice should be posted in that currency itself. [Click here](/docs/user/manual/en/accounts/multi-currency-accounting) to learn more about Multi Currency Accounting.
+* Maintain separate receivable account in the Customer's currency. The Receivable for this invoice should be posted in that currency itself. Read [Multi Currency Accounting](/docs/user/manual/en/accounts/multi-currency-accounting) to learn more.
 
 ### 3.6 Price list
 
 If you select a Price List, then the item prices will be fetched from that list. Ticking on 'Ignore Pricing Rule' will ignore the [Pricing Rules](/docs/user/manual/en/accounts/pricing-rule) set in Accounts > Pricing Rule.
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
+Read [Price List documentation](/docs/user/manual/en/stock/price-lists) to know more.
 
 
 ### 3.7 The Items table
@@ -117,7 +117,7 @@ To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
 #### Update Stock
 Ticking this checkbox will update the Stock Ledger on submitting the Sales Invoice. If you've created a Delivery Note, the Stock Ledger will be changed. If you're **skipping** the creation of Delivery Note, tick this checkbox.
 
-* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+* **scan barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * The Item Code, name, description, Image, and Manufacturer will be fetched from the [Item master](/docs/user/manual/en/stock/item).
 
@@ -194,7 +194,7 @@ The payment for an invoice may be made in parts depending on your understanding 
 Write off happens when the Customer pays an amount less than the invoice amount. This may be a small difference like 0.50. Over several orders, this might add up to a big number. For accounting accuracy, this difference amount is 'written off'. To know more, visit the [Payment Terms](/docs/user/manual/en/accounts/payment-entry#25-deductions-or-loss) page.
 
 ### 3.15 Terms and Conditions
-There may be certain terms and conditions on the Item you're selling, these can be applied here. To know about adding Terms and Conditions, [click here](/docs/user/manual/en/setting-up/print/terms-and-conditions).
+There may be certain terms and conditions on the Item you're selling, these can be applied here. Read [Terms and Condition documentation](/docs/user/manual/en/setting-up/print/terms-and-conditions) to know how to add them.
 
 ### 3.16 Transporter Information
 

--- a/erpnext_documentation/www/docs/user/manual/en/buying/buying-settings.md
+++ b/erpnext_documentation/www/docs/user/manual/en/buying/buying-settings.md
@@ -18,7 +18,7 @@ If not configured otherwise, ERPNext uses the Supplier's Name as the unique name
 
 You can define or select the Naming Series pattern from: **Settings > Data > Naming Series**
 
-[Click here](/docs/user/manual/en/setting-up/settings/naming-series) to know more about defining a Naming Series.
+Read [Naming Series](/docs/user/manual/en/setting-up/settings/naming-series) to know more about defining a Naming Series.
 
 ### 1.2 Default Supplier Group
 

--- a/erpnext_documentation/www/docs/user/manual/en/buying/purchase-order.md
+++ b/erpnext_documentation/www/docs/user/manual/en/buying/purchase-order.md
@@ -59,9 +59,9 @@ For India:
 ### 3.2 Currency and Price List
 You can set the currency in which the purchase order is to be stored. If you set a Pricing List, then the item prices will be fetched from that list. Ticking on Ignore Pricing Rule will ignore the Pricing Rules set in Accounts > Pricing Rule.
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
-
-To know about managing transactions in multiple currencies, [click here](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency).
+Read about [Price Lists](/docs/user/manual/en/stock/price-lists) 
+and [Multi-Currency Transactions](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency)
+to know more.
 
 ### 3.3 Subcontracting or 'Supply Raw Materials'
 
@@ -69,7 +69,7 @@ Setting 'Supply Raw Materials' option is useful for subcontracting where you pro
 
 ### 3.4 The Items table
 
-* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * **Quantity and Rate**: When you select the Item code, it's name, description, and UOM will be fetched. The 'UOM Conversion Factor' is set to 1 by default, you can change it depending on the UOM received from the seller, more in the next section.
 
@@ -155,7 +155,7 @@ Read [Applying Discount](/docs/user/manual/en/selling/articles/applying-discount
 ### 3.10 Payment Terms
 Sometimes payment is not done all at once. Depending on the agreement, half of the payment may be made before shipment and the other half after receiving the goods/services. You can add a Payment Terms template or add the terms manually in this section.
 
-To know more about Payment Terms, [click here](/docs/user/manual/en/accounts/payment-terms).
+Read [Payment Terms](/docs/user/manual/en/accounts/payment-terms) to know more.
 
 ### 3.11 Terms and Conditions
 In Sales/Purchase transactions there might be certain Terms and Conditions based on which the Supplier provides goods or services to the Customer. You can apply the Terms and Conditions to transactions to transactions and they will appear when printing the document. To know about Terms and Conditions, [click here](/docs/user/manual/en/setting-up/print/terms-and-conditions)

--- a/erpnext_documentation/www/docs/user/manual/en/buying/request-for-quotation.md
+++ b/erpnext_documentation/www/docs/user/manual/en/buying/request-for-quotation.md
@@ -113,7 +113,7 @@ After creation of Request for Quotation, there are two ways to generate Supplier
 
     ![RFQ status after supplier quote]({{docs_base_url}}/assets/img/buying/rfq-supplier-quoted.png)
 
-To know about creating a Supplier Quotation, [click here](/docs/user/manual/en/buying/supplier-quotation).
+Read [Supplier Quotation](/docs/user/manual/en/buying/supplier-quotation) to know more.
 
 ## 5. Video
 <div class="embed-container">

--- a/erpnext_documentation/www/docs/user/manual/en/customize-erpnext/articles/field-types.md
+++ b/erpnext_documentation/www/docs/user/manual/en/customize-erpnext/articles/field-types.md
@@ -115,7 +115,7 @@ The setting will be applicable on all the float field.
 
 Use Geolocation field to store GeoJSON <a href="https://tools.ietf.org/html/rfc7946#section-3.3">feature_collection</a>. Stores polygons, lines, and points. Internally it uses the following custom properties for identifying a circle.
 
-For more understanding, [click here](/docs/user/manual/en/customize-erpnext/articles/geolocation-field)
+Read [Geolocation field](/docs/user/manual/en/customize-erpnext/articles/geolocation-field) for more understanding.
 
 #### HTML
 
@@ -193,7 +193,7 @@ Section Break is used to divide the form into multiple sections.
 
 #### Signature
 
-You can define the field to be a Signature field wherein you can add the Digital Signature in this field. To know more, [click here](/docs/user/manual/en/customize-erpnext/articles/signature-field)
+You can define the field to be a Signature field wherein you can add the Digital Signature in this field. Read documentation for [Signature Field](/docs/user/manual/en/customize-erpnext/articles/signature-field) to know more.
 
 #### Table MultiSelect
 

--- a/erpnext_documentation/www/docs/user/manual/en/customize-erpnext/doctype.md
+++ b/erpnext_documentation/www/docs/user/manual/en/customize-erpnext/doctype.md
@@ -7,7 +7,7 @@ It describes the Model and the View of your data. It contains what fields are st
 
 DocType allows you to insert custom forms in ERPNext as per your requirement. 
 
-For more understanding on DocTypes, [click here](https://frappe.io/docs/user/en/understanding-doctypes)
+Read [DocType documentation](https://frappe.io/docs/user/en/understanding-doctypes) for more understanding.
 
 To create a new DocType, go to:
 

--- a/erpnext_documentation/www/docs/user/manual/en/education/lms-masters.md
+++ b/erpnext_documentation/www/docs/user/manual/en/education/lms-masters.md
@@ -18,7 +18,7 @@ If 'Allow Self Enroll' is not checked, the program will be visible to only those
 
 ![LMS Setting](/docs/assets/img/education/education-lms-3.png)
 
-Learn more about Programs [here](/docs/user/manual/en/education/program).
+Read about [Program](/docs/user/manual/en/education/program) to know more.
 
 ---
 
@@ -28,7 +28,7 @@ For each of the courses in a particular program, you can set a course intro and 
 
 ![LMS Setting](/docs/assets/img/education/education-lms-4.png)
 
-Learn more about courses [here](/docs/user/manual/en/education/course).
+Read [Courses](/docs/user/manual/en/education/course) to learn more.
 
 ---
 
@@ -37,7 +37,7 @@ Similar to the course, Topic has a table where you can add the content. You can 
 
 ![LMS Setting](/docs/assets/img/education/education-lms-13.png)
 
-Learn more about topics [here](/docs/user/manual/en/education/topic).
+Read [Topics](/docs/user/manual/en/education/topic) to learn more.
 
 ---
 

--- a/erpnext_documentation/www/docs/user/manual/en/introduction/getting-started-with-erpnext.md
+++ b/erpnext_documentation/www/docs/user/manual/en/introduction/getting-started-with-erpnext.md
@@ -28,8 +28,7 @@ To avoid the trouble of installing an instance, ERPNext is available as a
 Virtual Image (a full loaded operating system with ERPNext installed). You can
 use this on **any** platform including Microsoft Windows.
 
-[Click here to see instructions on how to use the Virtual
-Image](https://erpnext.com/download)
+[Instructions on how to use the Virtual Image](https://erpnext.com/download)
 
 ### 4\. Install ERPNext on your Unix/Linux/Mac machine
 

--- a/erpnext_documentation/www/docs/user/manual/en/projects/project-views.md
+++ b/erpnext_documentation/www/docs/user/manual/en/projects/project-views.md
@@ -27,7 +27,7 @@ Kanban in Japanese means "billboard" or "signboard" as the task management metho
 
 ERPNext renders the Kanban view for tasks based on its status. You can update the status of a task by moving the representative card from one column to the next. You can also assign colors to these columns for visual reference.
 
-To learn more about customizing the Kanban boards, [click here](/docs/user/manual/en/customize-erpnext/kanban-board).
+Read [customizing Kanban board](/docs/user/manual/en/customize-erpnext/kanban-board) to learn more.
 
 ## Calendar View
 

--- a/erpnext_documentation/www/docs/user/manual/en/selling/articles/applying-discount.md
+++ b/erpnext_documentation/www/docs/user/manual/en/selling/articles/applying-discount.md
@@ -11,7 +11,7 @@ You can find the Discount field in the Item table of a transaction, click on the
 
 The feature of Discount (%) is available in all sales and purchase transactions.
 
-If you want to apply a discount (as a Percentage) regularly for certain quantities you'd rather use a "Pricing Rule" [Click here to learn more about Pricing Rule  functionality](/docs/user/manual/en/accounts/pricing-rule).
+If you want to apply a discount (as a Percentage) regularly for certain quantities you'd rather use a "Pricing Rule". Read [Pricing Rule](/docs/user/manual/en/accounts/pricing-rule) documentation to learn more.
 
 ## 2. Discount on Net Total or Grand Total
 

--- a/erpnext_documentation/www/docs/user/manual/en/selling/articles/payment-terms.md
+++ b/erpnext_documentation/www/docs/user/manual/en/selling/articles/payment-terms.md
@@ -1,6 +1,6 @@
 # Payment Terms
 
-Sometimes payment is not done all at once. Depending on the agreement, half of the payment may be made before shipment and the other half after receiving the goods/services. You can add a Payment Terms template or add the terms manually in this section. To know more about Payment Terms, [click here](/docs/user/manual/en/accounts/payment-terms).
+Sometimes payment is not done all at once. Depending on the agreement, half of the payment may be made before shipment and the other half after receiving the goods/services. You can add a Payment Terms template or add the terms manually in this section. Read [Payment Terms](/docs/user/manual/en/accounts/payment-terms) to know more.
 
 <img class="screenshot" alt="Payment Terms in Quotation" src="{{docs_base_url}}/assets/img/selling/quotation-payment-terms.png">
 

--- a/erpnext_documentation/www/docs/user/manual/en/selling/quotation.md
+++ b/erpnext_documentation/www/docs/user/manual/en/selling/quotation.md
@@ -63,9 +63,9 @@ In this section there are four fields:
 ### 3.2 Currency and Price List
 You can set the currency in which the quotation/sales order is to be sent. If you set a Pricing List, then the item prices will be fetched from that list. Ticking on Ignore Pricing Rule will ignore the Pricing Rules set in Accounts > Pricing Rule.
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
-
-To know about managing transactions in multiple currencies, [click here](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency).
+Read about [Price Lists](/docs/user/manual/en/stock/price-lists) 
+and [Multi-Currency Transactions](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency)
+to know more.
 
 ### 3.3 The Items Table
 This table can be expanded by clicking on the inverted triangle present rightmost of the table.
@@ -106,7 +106,7 @@ Sometimes payment is not done all at once. Depending on the agreement, half of t
 
 <img class="screenshot" alt="Payment Terms in Quotation" src="{{docs_base_url}}/assets/img/selling/quotation-payment-terms.png">
 
-To know more about Payment Terms, [click here](/docs/user/manual/en/accounts/payment-terms).
+Read [Payment Terms](/docs/user/manual/en/accounts/payment-terms) to know more.
 
 ### 3.7 Terms and Conditions
 In Sales/Purchase transactions there might be certain Terms and Conditions based on which the Supplier provides goods or services to the Customer. You can apply the Terms and Conditions to transactions to transactions and they will appear when printing the document. To know about Terms and Conditions, [click here](/docs/user/manual/en/setting-up/print/terms-and-conditions)

--- a/erpnext_documentation/www/docs/user/manual/en/selling/sales-order.md
+++ b/erpnext_documentation/www/docs/user/manual/en/selling/sales-order.md
@@ -42,9 +42,9 @@ To allow for per-Customer, per-Item Pricing Rules, ("Customer A" pays $1.00 for 
 ### 3.1 Currency and Price List
 You can set the currency in which the quotation/sales order is to be sent. If you set a Pricing List, then the item prices will be fetched from that list. Ticking on 'Ignore Pricing Rule' will ignore the [Pricing Rules](/docs/user/manual/en/accounts/pricing-rule) set in Accounts > Pricing Rule.
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
-
-To know about managing transactions in multiple currencies, [click here](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency).
+Read about [Price Lists](/docs/user/manual/en/stock/price-lists) 
+and [Multi-Currency Transactions](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency)
+to know more.
 
 ### 3.1 Set Source Warehouse
 If you have the same stock in multiple warehouses, setting a warehouse here will cause all the items from the item table to be fetched from this warehouse. You need to have stock available in this 'source warehouse' you're setting. Note that this option will override the 'Default Warehouse' you've set in the Item master.
@@ -55,7 +55,7 @@ If you have the same stock in multiple warehouses, setting a warehouse here will
 
     A Sales Order displays the billed amount, valuation rate, and gross profit in the items table when you click on the inverted triangle to expand a row.
 
-    You can also add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+    You can also add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * **Delivery Warehouse**: This is the warehouse from where the stock will be picked to be delivered to your customer.
 
@@ -63,7 +63,7 @@ If you have the same stock in multiple warehouses, setting a warehouse here will
 
     Further, if you create a purchase order from this sales order, it'll be created for the supplier you selected here and only the items which are valid for drop shipping.
 
-* **Planning**: To know about the fields under planning [click here](/docs/user/manual/en/stock/projected-quantity).
+* **Planning**: Read [Projected Quantity](/docs/user/manual/en/stock/projected-quantity) to know about the fields under planning.
 
 The other fields in the item table are similar as explained in [Quotation](/docs/user/manual/en/selling/quotation#23-the-items-table).
 
@@ -99,7 +99,7 @@ Read [Applying Discount](/docs/user/manual/en/selling/articles/applying-discount
 ### 3.6 Payment Terms
 Sometimes payment is not done all at once. Depending on the agreement, half of the payment may be made before shipment and the other half after receiving the goods/services. You can add a Payment Terms template or add the terms manually in this section.
 
-To know more about Payment Terms, [click here](/docs/user/manual/en/accounts/payment-terms).
+Read [Payment Terms](/docs/user/manual/en/accounts/payment-terms) to know more.
 
 ### 3.7 Terms and Conditions
 In Sales/Purchase transactions there might be certain Terms and Conditions based on which the Supplier provides goods or services to the Customer. You can apply the Terms and Conditions to transactions to transactions and they will appear when printing the document. To know about Terms and Conditions, [click here](/docs/user/manual/en/setting-up/print/terms-and-conditions)

--- a/erpnext_documentation/www/docs/user/manual/en/setting-up/email/email-inbox.md
+++ b/erpnext_documentation/www/docs/user/manual/en/setting-up/email/email-inbox.md
@@ -46,7 +46,7 @@ If you are creating an Email Account for your colleague who's Email Password is 
 
 > If you are creating an Email Account for Email Inbox of a User, then leave Append To field as blank.
 
-For more details on how to setup an Email Account, [click here](/docs/user/manual/en/setting-up/email/email-account).
+Read [Email Account documentation](/docs/user/manual/en/setting-up/email/email-account) for more details on how to setup.
 
 ## 4. Linking Email Account in the User master
 

--- a/erpnext_documentation/www/docs/user/manual/en/setting-up/print/print-settings.md
+++ b/erpnext_documentation/www/docs/user/manual/en/setting-up/print/print-settings.md
@@ -90,7 +90,7 @@ This is executed from the `frappe-bench` directory.
 
 ## 4. Raw Printing
 
-You can enable raw printing and print to many supported thermal printers. [Click here to know more about Raw Printing.](/docs/user/manual/en/setting-up/print/raw-printing)
+You can enable raw printing and print to many supported thermal printers. Read [Raw Printing](/docs/user/manual/en/setting-up/print/raw-printing) to know more.
 
 ### 5. Related Topics
 1. [Print Format](/docs/user/manual/en/setting-up/print/print-format)

--- a/erpnext_documentation/www/docs/user/manual/en/setting-up/setting-up-taxes.md
+++ b/erpnext_documentation/www/docs/user/manual/en/setting-up/setting-up-taxes.md
@@ -16,19 +16,19 @@ Select an account and click on edit. Select the 'Account Type' as 'Tax' for the 
 
 ## 2. Sales Taxes and Charges Template
 Sales Taxes and Charges Template fetched taxes for your sales transactions like [Sales Order](/docs/user/manual/en/selling/sales-order) and [Sales Invoice](/docs/user/manual/en/accounts/sales-invoice).
-[Click here](/docs/user/manual/en/selling/sales-taxes-and-charges-template) to know about this.
+Read [Sales Taxes and Charges Template](/docs/user/manual/en/selling/sales-taxes-and-charges-template) to know more.
 
 ## 3. Purchase Taxes and Charges Template
 Purchase Taxes and Charges Template fetched taxes for your sales transactions like [Purchase Order](/docs/user/manual/en/buying/purchase-order) and [Purchase Invoice](/docs/user/manual/en/accounts/purchase-invoice).
-[Click here](/docs/user/manual/en/buying/purchase-taxes-and-charges-template) to know about this.
+Read [Purchase Taxes and Charges Template](/docs/user/manual/en/buying/purchase-taxes-and-charges-template) to know more.
 
 ## 4. Item Tax Template
 The tax set in Item Tax Template applies specifically to an [Item](/docs/user/manual/en/stock/item) or an [Item Group](/docs/user/manual/en/stock/item-group). It is given preference over the Sales/Purchase Tax Template.
-[Click here](/docs/user/manual/en/accounts/item-tax-template) to know about this.
+Read [Item Tax Template](/docs/user/manual/en/accounts/item-tax-template) to know more.
 
 ## 5. Tax Category
 Tax category helps in automatically applying sales/purchase tax templates in your transactions based on the customer/supplier chosen.
-[Click here](/docs/user/manual/en/accounts/tax-category) to know about this.
+Read [Tax Category](/docs/user/manual/en/accounts/tax-category) to know more.
 
 ## 6. Video
 

--- a/erpnext_documentation/www/docs/user/manual/en/setting-up/users-and-permissions/adding-users.md
+++ b/erpnext_documentation/www/docs/user/manual/en/setting-up/users-and-permissions/adding-users.md
@@ -9,7 +9,7 @@ There are two main types of users:
 **Website users**: Customers, Suppliers, Students, etc., who have access only to the portal and not to any modules.
 **System Users**: People using ERPNext in the Company with access to modules, company data, etc.
 
-To know more about these two type of users, [click here](/docs/user/manual/en/setting-up/articles/difference-between-system-user-and-website-user).
+Read more about [difference between system and website user](/docs/user/manual/en/setting-up/articles/difference-between-system-user-and-website-user).
 
 Under User, a lot of info can be entered. For the sake of usability, the information entered for web users is minimal: First Name and Email.
 

--- a/erpnext_documentation/www/docs/user/manual/en/stock/accounting-of-inventory-stock.md
+++ b/erpnext_documentation/www/docs/user/manual/en/stock/accounting-of-inventory-stock.md
@@ -19,8 +19,9 @@ the value as per Stock Ledger always remains the same with the relevant account
 balance. This improves the accuracy of the Balance Sheet and the Profit and Loss
 statement.
 
-To check accounting entries for a particular stock transaction,
-[click here](/docs/user/manual/en/stock/perpetual-inventory)
+Read [Perpetual Inventory documentation](/docs/user/manual/en/stock/perpetual-inventory)
+to check accounting entries for a particular stock transaction.
+
 
 ### 1.2 Advantages of Perpetual Inventory
 

--- a/erpnext_documentation/www/docs/user/manual/en/stock/articles/managing-batch-wise-inventory.md
+++ b/erpnext_documentation/www/docs/user/manual/en/stock/articles/managing-batch-wise-inventory.md
@@ -11,7 +11,7 @@ You can create a new Batch from:
 
 `Stock > Documents > Batch > New`
 
-To learn more about batch, click [here.](/docs/user/manual/en/stock/batch.html)
+Read [Stock batch](/docs/user/manual/en/stock/batch.html) to learn more.
 
 For the Batch item, updating Batch No. in the stock transactions (Purchase Receipt & Delivery Note) is mandatory.
 

--- a/erpnext_documentation/www/docs/user/manual/en/stock/delivery-note.md
+++ b/erpnext_documentation/www/docs/user/manual/en/stock/delivery-note.md
@@ -76,9 +76,9 @@ For India, the following details can be added for GST:
 ### 3.3 Currency and Price List
 You can set the currency in which the Deliver Note is to be sent. This is usually fetched if set in the Sales Order. If you set a Pricing List, then the item prices will be fetched from that list. Ticking on Ignore Pricing Rule will ignore the Pricing Rules set in Accounts > Pricing Rule.
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
-
-To know about managing transactions in multiple currencies, [click here](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency).
+Read about [Price Lists](/docs/user/manual/en/stock/price-lists) 
+and [Multi-Currency Transactions](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency)
+to know more.
 
 ### 3.4 Warehouses
 
@@ -90,7 +90,7 @@ To know about managing transactions in multiple currencies, [click here](/docs/u
 
 * The Item Code, name, description, Image, and Manufacturer will be fetched from the [Item master](/docs/user/manual/en/stock/item).
 
-* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * **Discount and Margin**: You can apply a discount on individual Items percentage-wise or the total amount of the Item. Read [Applying Discount](/docs/user/manual/en/selling/articles/applying-discount) for more details.
 

--- a/erpnext_documentation/www/docs/user/manual/en/stock/item.md
+++ b/erpnext_documentation/www/docs/user/manual/en/stock/item.md
@@ -90,7 +90,7 @@ Barcodes can be recorded in Items to quickly scan and add them in transactions. 
 * **Weight UOM**: The Unit of Measure for the item. This can be Nos, Kilo, etc. The Weight UoM which you use internally can be different from the purchase UoM.
 * **Weight Per Unit**: The actual weight per unit of the item. Eg: 1 kilo biscuits or 10 biscuits per pack.
 * **Default Material Request Type**: When you create a new Material Request for this item, the field set here will be selected by default in the new Material Request. This is also known as an 'indent'.
-* **Valuation Method**: Select the Valuation Method whether FIFO or Moving Average. To know more about Valuation Methods, [click here](/docs/user/manual/en/stock/articles/item-valuation-fifo-and-moving-average).
+* **Valuation Method**: Select the Valuation Method whether FIFO or Moving Average. Read [Item Valuation methods](/docs/user/manual/en/stock/articles/item-valuation-fifo-and-moving-average) to know more.
 
 ### 3.4 Automatic Reordering
 When the stock of an item dips under a certain quantity, you can set an automatic reorder under 'Auto Reorder' section. This should be enabled in [Stock Settings](/docs/user/manual/en/stock/stock-settings#9-automatic-material-request). This will raise a [Material Request](/docs/user/manual/en/stock/material-request) for the Item. The user with roles Purchase Manager and Stock Manager will be **notified** when the Material Request is created.
@@ -234,7 +234,7 @@ You can also set a [Tax Category](/docs/user/manual/en/accounts/tax-category) fo
 
 Quality Inspection can be done with Quick View and you need not go to a different page to update the details inspection in ERPNext.
 
-To know more about Quality Inspection, [click here](/docs/user/manual/en/stock/quality-inspection).
+Read [Quality Inspection](/docs/user/manual/en/stock/quality-inspection) to know more.
 
 ### 3.18 Manufacturing
 

--- a/erpnext_documentation/www/docs/user/manual/en/stock/material-request.md
+++ b/erpnext_documentation/www/docs/user/manual/en/stock/material-request.md
@@ -60,7 +60,7 @@ These are the statuses a Material Request can be in:
 
 * The Item Code, name, description, Image, and Manufacturer will be fetched from the Item master.
 
-* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * The UoM, Conversion Factor, and Amount will be fetched. You change the Warehouse for which the material is being requested.
 
@@ -76,7 +76,8 @@ In the 'Requested For' field, you can set a Reference from where Material Reques
 
 ### 2.4 Printing Details
 #### Letterhead
-You can print your Material Request on your company's letterhead. [Click here](/docs/user/manual/en/setting-up/print/letter-head) to learn more.
+You can print your Material Request on your company's letterhead. 
+Read [Letter head documentation](/docs/user/manual/en/setting-up/print/letter-head) to learn more.
 
 #### Print Headings
 Purchase Receipt headings can also be changed when printing the document. You can do this by selecting a **Print Heading**. To create new Print Headings go to: Home > Settings > Printing > Print Heading. Know more [here](/docs/user/manual/en/setting-up/print/print-headings).

--- a/erpnext_documentation/www/docs/user/manual/en/stock/purchase-receipt.md
+++ b/erpnext_documentation/www/docs/user/manual/en/stock/purchase-receipt.md
@@ -57,7 +57,9 @@ The currency of the Purchase Receipt is shown in this section, it is fetched fro
 
 Since the incoming Item affects the value of your inventory, it is important to convert it into your base currency if you have ordered in another Currency. You will need to update the Currency Conversion Rate if applicable.
 
-To know about Price Lists, [click here](/docs/user/manual/en/stock/price-lists).
+Read about [Price Lists](/docs/user/manual/en/stock/price-lists) 
+and [Multi-Currency Transactions](/docs/user/manual/en/accounts/articles/managing-transactions-in-multiple-currency)
+to know more.
 
 ### 3.2 Warehouse details
 The following Warehouses set will apply to all Items in the Items table of the Purchase Receipt. You can change the Warehouses for individual Items via the table.
@@ -67,13 +69,13 @@ The following Warehouses set will apply to all Items in the Items table of the P
 
 #### Subcontracting
 
-* **Raw Materials Consumed**: In case you're subcontracting, select 'Yes' to consume the Raw Materials from the vendor. To know more about subcontracting, [click here](/docs/user/manual/en/manufacturing/subcontracting).
+* **Raw Materials Consumed**: In case you're subcontracting, select 'Yes' to consume the Raw Materials from the vendor. Read [Subcontracting](/docs/user/manual/en/manufacturing/subcontracting) to know more.
 
 ### 3.3 Items table
 
 * **Barcode**: You can track Items using [barcodes](/docs/user/manual/en/stock/articles/track-items-using-barcode).
 
-* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Know how to track them [here](/docs/user/manual/en/stock/articles/track-items-using-barcode)
+* **Scan Barcode**: You can add Items in the Items table by scanning their barcodes if you have a barcode scanner. Read documentation for [tracking items using barcode](/docs/user/manual/en/stock/articles/track-items-using-barcode) to know more.
 
 * The Item Code, name, description, Image, and Manufacturer will be fetched from the Item master.
 

--- a/erpnext_documentation/www/docs/user/manual/en/using-erpnext/articles/tree-master-renaming.md
+++ b/erpnext_documentation/www/docs/user/manual/en/using-erpnext/articles/tree-master-renaming.md
@@ -3,7 +3,7 @@
 
 **There are various documents in ERPNext which are maintained in a tree structure.**
 
-Click [here](/docs/user/manual/en/setting-up/articles/managing-tree-structure-masters.html) to learn more about tree-structured masters in ERPNext.
+Read about [managing tree structures](/docs/user/manual/en/setting-up/articles/managing-tree-structure-masters.html) to learn more.
 
 Following are the steps to be followed for renaming the ID of a master which is maintained in a tree structure. Let's rename an Account for the instance.
 

--- a/erpnext_documentation/www/docs/user/manual/en/website/product-page.md
+++ b/erpnext_documentation/www/docs/user/manual/en/website/product-page.md
@@ -15,7 +15,7 @@ Product Page is built for an Item. If you haven't created any Item go to:
 1. Click on Save.
 1. View your Product Page by clicking on **Show on Website** in the sidebar.
 
-> Learn more about creating an Item [here](/docs/user/manual/en/stock/item).
+> Read [Item documentation](/docs/user/manual/en/stock/item) to learn more.
 
 ### 1.1 Items with Variants
 

--- a/erpnext_documentation/www/docs/user/manual/en/website/web-form.md
+++ b/erpnext_documentation/www/docs/user/manual/en/website/web-form.md
@@ -104,8 +104,8 @@ You can write custom scripts for your Web Form for things like validating your
 inputs, auto-filling values, showing a success message, or any arbitrary
 action.
 
-Learn how to write custom scripts for your Web Forms
-[here](https://frappe.io/docs/user/en/web-forms#custom-script).
+To learn how to write custom scripts for your Web Forms, read
+[Custom Scripts documentation](https://frappe.io/docs/user/en/web-forms#custom-script).
 
 ### 2.6 Custom CSS
 


### PR DESCRIPTION
Refer to #120. "Click here" links are not good for accessibility and SEO. 

Description:
Replace most of of "Click here" link with title of documentation. This was mostly done with macros and reviewed later by me, so all instances are not updated. This covers ~50% of required changes as of now.

Count before:
```
❯ rg -i -c "click here" | cut -d ':' -f2 | jq -s add
83
```

Count after:
```
❯ rg -i -c "click here" | cut -d ':' -f2 | jq -s add
41
```

I'll work on remaining ones if this is acceptable. 