### PR TITLE
fix: Spell Checker requires Node v12

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '12.x'
     - name: Setup cSpell
       run: npm i -g cspell
     - name: Run cSpell


### PR DESCRIPTION
The Spell Checking GitHub Action failed due to errors while running cSpell when there are any spelling mistakes in a given file of a PR. It should report the spelling mistakes instead. 
This was due to Node version incompatibility: the **cSpell NPM package uses some functions that are only supported in Node v12+**.  There are no errors when there is no spelling mistake because that specific function are called only when there is a spelling mistake.

Node v10:
![1](https://user-images.githubusercontent.com/34810212/113565002-ebddba80-9627-11eb-9952-a10d235b5ead.png)

Node v12:
![2](https://user-images.githubusercontent.com/34810212/113565030-f4ce8c00-9627-11eb-8b16-74f3f1ae2256.png)
