### PR TITLE
fix: unintentional code block rendering

### DIFF
--- a/erpnext_documentation/www/docs/v12/user/manual/en/quality-management/quality_action.md
+++ b/erpnext_documentation/www/docs/v12/user/manual/en/quality-management/quality_action.md
@@ -17,11 +17,8 @@ To access Quality Action, go to:
 ## 1. Prerequisites
 
 Before creating and using a Quality Action it is advised to create the following first:
-* [Quality Review](/docs/user/manual/en/quality-management/quality_review)
 
-    Or
-
-* [Quality Feedback](/docs/user/manual/en/quality-management/quality_feedback)
+* [Quality Review](/docs/user/manual/en/quality-management/quality_review) or [Quality Feedback](/docs/user/manual/en/quality-management/quality_feedback)
 
 ## 2. How to create a Quality Action
 

--- a/erpnext_documentation/www/docs/v12/user/manual/en/stock/sales-return.md
+++ b/erpnext_documentation/www/docs/v12/user/manual/en/stock/sales-return.md
@@ -9,11 +9,7 @@ Businesses often return goods that are already sold. They could be returned by t
 Before creating and using a Sales Return, it is advised that you create the following first:
 
 * [Item](/docs/user/manual/en/stock/item)
-* [Sales Invoice](/docs/user/manual/en/accounts/sales-invoice)
-
-    Or
-
-    [Delivery Note](/docs/user/manual/en/stock/delivery-note)
+* [Sales Invoice](/docs/user/manual/en/accounts/sales-invoice) or [Delivery Note](/docs/user/manual/en/stock/delivery-note)
 
 ## 2. How to create a Sales Return
 

--- a/erpnext_documentation/www/docs/v13/user/manual/en/quality-management/quality_action.md
+++ b/erpnext_documentation/www/docs/v13/user/manual/en/quality-management/quality_action.md
@@ -18,7 +18,7 @@ To access Quality Action, go to:
 
 Before creating and using a Quality Action it is advised to create the following first:
 
-[Quality Review](/docs/v13/user/manual/en/quality-management/quality_review) or [Quality Feedback](/docs/v13/user/manual/en/quality-management/quality_feedback)
+* [Quality Review](/docs/v13/user/manual/en/quality-management/quality_review) or [Quality Feedback](/docs/v13/user/manual/en/quality-management/quality_feedback)
 
 ## 2. How to create a Quality Action
 

--- a/erpnext_documentation/www/docs/v13/user/manual/en/stock/sales-return.md
+++ b/erpnext_documentation/www/docs/v13/user/manual/en/stock/sales-return.md
@@ -9,11 +9,7 @@ Businesses often return goods that are already sold. They could be returned by t
 Before creating and using a Sales Return, it is advised that you create the following first:
 
 * [Item](/docs/v13/user/manual/en/stock/item)
-* [Sales Invoice](/docs/v13/user/manual/en/accounts/sales-invoice)
-
-    Or
-
-    [Delivery Note](/docs/v13/user/manual/en/stock/delivery-note)
+* [Sales Invoice](/docs/v13/user/manual/en/accounts/sales-invoice) or [Delivery Note](/docs/v13/user/manual/en/stock/delivery-note)
 
 ## 2. How to create a Sales Return
 


### PR DESCRIPTION
Problem: ![image](https://user-images.githubusercontent.com/9079960/118112627-e29ff480-b402-11eb-92ab-32507d4f4da1.png)


4 spaces => start of code block in markdown. As either of the option is okay in the following case they can be on a single line instead.

