### PR TITLE
Present two points under Employee Benefit Claim as two separate bullet points 

### DIFF
--- a/erpnext_documentation/www/docs/user/manual/en/human-resources/employee-benefit-claim.md
+++ b/erpnext_documentation/www/docs/user/manual/en/human-resources/employee-benefit-claim.md
@@ -2,7 +2,9 @@
 #Employee Benefit Claim
 
 Employee Benefit Claim allows Employees to -
+
  1. Claim flexible benefits which are to be received lump-sum (if Salary Component is _Pay Against Benefit Claim_)
+ 
  2. Claim tax exemption for flexible benefits received pro-rata, as part of salary when _Deduct Tax For Unclaimed Employee Benefits_ is checked in Payroll Entry / Salary Slip
 
 You can create a new Employee Benefit Claim by going to,

--- a/erpnext_documentation/www/docs/user/manual/en/selling/articles/sales-persons-in-the-sales-transactions.md
+++ b/erpnext_documentation/www/docs/user/manual/en/selling/articles/sales-persons-in-the-sales-transactions.md
@@ -13,7 +13,7 @@ If more than one sales persons are working together on an order, then contributi
 
 <img class="screenshot" alt="Sales Person Order" src="{{docs_base_url}}/assets/img/articles/sales-person-transaction-2.png">
 
-On saving transaction, based on the Net Total and Contriution (%), `Contribution to Net Total` will be calculated for each Sales Person.
+On saving transaction, based on the Net Total and Contribution (%), `Contribution to Net Total` will be calculated for each Sales Person.
 
 <div class=well>Total % Contribution for all Sales Person must be 100%. If only one Sales Person is selected, then % Contribution will be 100.</div>
 


### PR DESCRIPTION
Under the heading of Employee Benefit Claim, create two separate bullet points for point 1 and point 2 enlisting its usage : 

![Screenshot 2021-06-03 at 2 32 17 PM](https://user-images.githubusercontent.com/32797974/120626261-1d380280-c480-11eb-9a24-d22a7f7a8fb8.png)
