### PR TITLE
fix: Spelling Correction in Sales Person in the Sales Transaction page

### DIFF
--- a/erpnext_documentation/www/docs/user/manual/en/selling/articles/sales-persons-in-the-sales-transactions.md
+++ b/erpnext_documentation/www/docs/user/manual/en/selling/articles/sales-persons-in-the-sales-transactions.md
@@ -13,7 +13,7 @@ If more than one sales persons are working together on an order, then contributi
 
 <img class="screenshot" alt="Sales Person Order" src="{{docs_base_url}}/assets/img/articles/sales-person-transaction-2.png">
 
-On saving transaction, based on the Net Total and Contriution (%), `Contribution to Net Total` will be calculated for each Sales Person.
+On saving transaction, based on the Net Total and Contribution (%), `Contribution to Net Total` will be calculated for each Sales Person.
 
 <div class=well>Total % Contribution for all Sales Person must be 100%. If only one Sales Person is selected, then % Contribution will be 100.</div>
 


### PR DESCRIPTION
The spelling of the word "Contribution" is incorrect on the Sales Person in the Sales Transaction Page 

![Screenshot 2021-05-24 at 2 57 47 PM](https://user-images.githubusercontent.com/32797974/120636339-27abc980-c48b-11eb-9294-e1db0ef0da1a.png)
